### PR TITLE
Update resource.h

### DIFF
--- a/app/resources/resource.h
+++ b/app/resources/resource.h
@@ -1,16 +1,27 @@
 //{{NO_DEPENDENCIES}}
-// Microsoft Visual C++ 生成的包含文件。
-// 供 app.rc 使用
+// Microsoft Visual C++ generated include file.
+// Used by app.rc
 //
-#define IDI_ICON1                       101
+// Note: The //{{NO_DEPENDENCIES}} and //}}NO_DEPENDENCIES}} markers are used by Visual Studio
+// to identify blocks of symbols defined by the resource editor. Avoid manual edits
+// within these blocks if using the visual editor extensively.
 
-// Next default values for new objects
-// 
+#pragma once // More modern alternative to traditional include guards for many compilers
+
+// Define resource IDs
+#define IDI_ICON1                       101 // Example: Main application icon ID
+
+// Next default values for new objects added via the resource editor
+// Only active when APSTUDIO_INVOKED is defined (i.e., within the VS resource editor)
 #ifdef APSTUDIO_INVOKED
-#ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        102
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1001
-#define _APS_NEXT_SYMED_VALUE           101
+    #ifndef APSTUDIO_READONLY_SYMBOLS
+        // The resource editor will use these values as the starting point
+        // when assigning IDs to newly created resources of different types.
+        #define _APS_NEXT_RESOURCE_VALUE        102 // Next available value for general resources (dialogs, strings, etc.)
+        #define _APS_NEXT_COMMAND_VALUE         40001 // Next available value for command IDs (menus, accelerators)
+        #define _APS_NEXT_CONTROL_VALUE         1001 // Next available value for control IDs within dialogs
+        #define _APS_NEXT_SYMED_VALUE           101 // Next available value for symbol-only resources (can sometimes overlap initially)
+    #endif
 #endif
-#endif
+
+//}}NO_DEPENDENCIES}} // End of the Visual Studio managed block


### PR DESCRIPTION
English Comments: All comments are now in English for broader understanding.
Added pragma once: This is a common and often more efficient way to prevent multiple inclusions of the header file compared to traditional #ifndef/#define/#endif guards, especially for resource headers primarily included by the .rc file itself.
Clarified //{{NO_DEPENDENCIES}}: Added a comment explaining its purpose and the corresponding //}}NO_DEPENDENCIES}} marker (which wasn't in the original but is often paired).
Commented IDI_ICON1: Added a specific comment indicating what IDI_ICON1 might represent (e.g., "Main application icon ID"). You should update this comment to reflect the actual use of the icon.
Clarified APSTUDIO_INVOKED Block: Added comments explaining why this block exists (for the resource editor) and what the _APS_NEXT_... values mean.
Improved Readability: Slightly adjusted spacing and formatting for better visual structure.