### PR TITLE
Update _MSC_VER max version to 1944

### DIFF
--- a/third_party/ruby_extern/config/x64/ruby/config.h
+++ b/third_party/ruby_extern/config/x64/ruby/config.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_RUBY_CONFIG_H
 #define INCLUDE_RUBY_CONFIG_H 1
-#if (_MSC_VER < 1920) || (_MSC_VER > 1942)
-#error MSC version unmatch: 1920..1939 is expected.
+#if (_MSC_VER < 1920) || (_MSC_VER > 1944)
+#error MSC version unmatch: 1920..1944 is expected.
 #endif
 #define HAVE_TYPE_STRUCT_ADDRINFO
 #define RUBY_MSVCRT_VERSION 140

--- a/third_party/ruby_extern/config/x86/ruby/config.h
+++ b/third_party/ruby_extern/config/x86/ruby/config.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDE_RUBY_CONFIG_H
 #define INCLUDE_RUBY_CONFIG_H 1
-#if (_MSC_VER < 1920) || (_MSC_VER > 1939)
-#error MSC version unmatch: 1920..1939 is expected.
+#if (_MSC_VER < 1920) || (_MSC_VER > 1944)
+#error MSC version unmatch: 1920..1944 is expected.
 #endif
 #define RUBY_MSVCRT_VERSION 140
 #define STDC_HEADERS 1


### PR DESCRIPTION
Updated _MSC_VER upper bound to 1944 (VS 2022 17.14). The project builds successfully in more recent Visual Studio environments.

(While compiling I ran into this problem and it is quite simple to solve)